### PR TITLE
Metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,13 +14,13 @@ var bufferGraph = require('buffer-graph')
 var key = Buffer.from('my very cool graphing key')
 
 var graph = bufferGraph(key)
-graph.on('change', function (nodeName, edgeName, state) {
-  console.log(`${nodeName}:${edgeName} changed to ${state[name].hash}`)
+graph.on('change', function (name, data) {
+  console.log(`${nodeName}:${edgeName} changed to ${data[name].hash}`)
 })
 
 // Triggers when graph.start() is called
-graph.node('first', function (state, edge) {
-  console.log('initial state is', state.metadata)
+graph.node('first', function (data, edge) {
+  console.log('initial data is', data.metadata)
   edge('foo', Buffer.from('beep'))
   setTimeout(function () {
     edge('bar', Buffer.from('boop'))
@@ -28,10 +28,10 @@ graph.node('first', function (state, edge) {
 })
 
 // Triggers once first:foo and first:bar have been created. Retriggers if
-// either dependency changes, and the state has a different hash.
-graph.node('second', [ 'first:foo', 'first:bar' ], function (state, edge) {
-  console.log('first:foo', state.first.foo)
-  console.log('first:bar', state.first.bar)
+// either dependency changes, and the data has a different hash.
+graph.node('second', [ 'first:foo', 'first:bar' ], function (data, edge) {
+  console.log('first:foo', data.first.foo)
+  console.log('first:bar', data.first.bar)
   edge('baz', Buffer.from('berp'))
 })
 
@@ -53,7 +53,7 @@ Create a new node in the buffer graph.
 ### `graph.start([metadata])`
 Start the graph. Can be passed `metadata` which is set as `state.metadata`.
 
-### `graph.state`
+### `graph.data`
 Read out the data from the graph.
 
 ### `graph.metadata`

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ graph.on('change', function (nodeName, edgeName, state) {
 
 // Triggers when graph.start() is called
 graph.node('first', function (state, edge) {
-  console.log('initial state is', state.arguments)
+  console.log('initial state is', state.metadata)
   edge('foo', Buffer.from('beep'))
   setTimeout(function () {
     edge('bar', Buffer.from('boop'))
@@ -50,8 +50,14 @@ Create a new `buffer-graph` instance. Inherits from Node's
 ### `graph.node(name, [dependencies], fn(state, edge))`
 Create a new node in the buffer graph.
 
-### `graph.start([arguments])`
-Start the graph. Can be passed `arguments` which is set as `state.arguments`
+### `graph.start([metadata])`
+Start the graph. Can be passed `metadata` which is set as `state.metadata`.
+
+### `graph.state`
+Read out the data from the graph.
+
+### `graph.metadata`
+Read out the metadata from the graph.
 
 ## License
 [MIT](https://tldrlegal.com/license/mit-license)

--- a/index.js
+++ b/index.js
@@ -58,11 +58,12 @@ BufferGraph.prototype.node = function (nodeName, dependencies, handler) {
   return this
 }
 
-BufferGraph.prototype.start = function (data) {
+BufferGraph.prototype.start = function (metadata) {
   assert.ok(this.roots.length, 'buffer-graph.start: no roots detected, cannot start the graph')
 
   var self = this
-  this.data.arguments = data
+  this.data.metadata = metadata
+  this.metadata = metadata
 
   init()
 

--- a/index.js
+++ b/index.js
@@ -15,7 +15,8 @@ function BufferGraph (key) {
   this.nodes = {}  // references to all nodes, keeps state except "data"
   this.data = {}  // data that is passed into each node
 
-  this.data.metadata = {}  // non-buffer metadata, does not cause triggers
+  this.metadata = {}  // non-buffer metadata, does not cause triggers
+  this.data.metadata = this.metadata
 }
 BufferGraph.prototype = Object.create(Emitter.prototype)
 

--- a/index.js
+++ b/index.js
@@ -13,9 +13,9 @@ function BufferGraph (key) {
   this.key = key
   this.roots = []  // nodes that should be resolved when .start() is called
   this.nodes = {}  // references to all nodes, keeps state except "data"
-  this.state = {}  // data that is passed into each node
+  this.data = {}  // data that is passed into each node
 
-  this.state.metadata = {}  // non-buffer metadata, does not cause triggers
+  this.data.metadata = {}  // non-buffer metadata, does not cause triggers
 }
 BufferGraph.prototype = Object.create(Emitter.prototype)
 
@@ -36,7 +36,7 @@ BufferGraph.prototype.node = function (nodeName, dependencies, handler) {
   node.dependencies = dependencies
   node.handler = handler.bind(this)
 
-  this.state[nodeName] = {}
+  this.data[nodeName] = {}
 
   if (dependencies.length === 0) {
     this.roots.push(nodeName)
@@ -62,7 +62,7 @@ BufferGraph.prototype.start = function (metadata) {
   assert.ok(this.roots.length, 'buffer-graph.start: no roots detected, cannot start the graph')
 
   var self = this
-  this.state.metadata = metadata
+  this.data.metadata = metadata
   this.metadata = metadata
 
   init()
@@ -70,7 +70,7 @@ BufferGraph.prototype.start = function (metadata) {
   function init () {
     self.roots.forEach(function (nodeName) {
       var node = self.nodes[nodeName]
-      node.handler(self.state, createEdge(nodeName))
+      node.handler(self.data, createEdge(nodeName))
     })
   }
 
@@ -79,7 +79,7 @@ BufferGraph.prototype.start = function (metadata) {
       assert.equal(typeof edgeName, 'string', 'buffer-graph.node.createEdge: edgeName should be type string at ' + nodeName + ':' + edgeName)
       assert.equal(Buffer.isBuffer(data), true, 'buffer-graph.node.createEdge: data should be a buffer at ' + nodeName + ':' + edgeName)
 
-      var dataNode = self.state[nodeName]
+      var dataNode = self.data[nodeName]
       var node = self.nodes[nodeName]
       var hash = new Uint8Array(16)
       hash = blake2b(hash.length, self.key).update(data).digest('hex').slice(16)
@@ -106,10 +106,10 @@ BufferGraph.prototype.start = function (metadata) {
           assert.ok(node, 'buffer-graph ' + dependentName + ' relies on non-existant dependency ' + dep)
           return node.triggered[b] === true
         })
-        if (ok) handler(self.state, createEdge(dependentName))
+        if (ok) handler(self.data, createEdge(dependentName))
       })
 
-      self.emit('change', nodeName, edgeName, self.state)
+      self.emit('change', nodeName, edgeName, self.data)
     }
   }
 }

--- a/test.js
+++ b/test.js
@@ -11,7 +11,7 @@ tape('should provide initial data', function (assert) {
   var graph = bufferGraph(key)
   graph.node('first', function (data, edge) {
     spok(assert, data, {
-      arguments: {
+      metadata: {
         hi: 'kittens'
       }
     })


### PR DESCRIPTION
Major version, https://github.com/yoshuawuyts/buffer-graph/pull/3 requesting because should be bumped as major too.

Renames `this.data.arguments` to `this.metadata` which should be easier to parse - and also more correct because it can be modified at any given time. Thanks!