### PR TITLE
use sha512

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "test": "standard && npm run deps && node test"
   },
   "dependencies": {
-    "blakejs": "^1.1.0"
   },
   "devDependencies": {
     "dependency-check": "^2.9.1",

--- a/test.js
+++ b/test.js
@@ -35,7 +35,7 @@ tape('should resolve a graph', function (assert) {
       first: {
         foo: {
           buffer: spok.type('object'),
-          hash: spok.string
+          hash: spok.type('object')
         }
       }
     })
@@ -63,11 +63,11 @@ tape('should resolve a graph with 2 dependencies', function (assert) {
       first: {
         foo: {
           buffer: spok.type('object'),
-          hash: spok.string
+          hash: spok.type('object')
         },
         bar: {
           buffer: spok.type('object'),
-          hash: spok.string
+          hash: spok.type('object')
         }
       }
     })


### PR DESCRIPTION
- exposes hashes as buffers (for more flexibility)
- replaced hashing algo with sha512 so we can perform [subresource integrity checks](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity)

Thanks!